### PR TITLE
Switch to meilisearch-python-async

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,12 +1,12 @@
 anyio==3.7.0
-camel-converter==3.0.0
+camel-converter==3.0.2
 certifi==2023.5.7
 charset-normalizer==3.1.0
 click==8.1.3
 fastapi==0.97.0
 h11==0.14.0
 idna==3.4
-meilisearch==0.28.0
+meilisearch-python-async==1.4.6
 pydantic==1.10.9
 requests==2.31.0
 sniffio==1.3.0


### PR DESCRIPTION
The currrent implementation is using async functions with `meilisearch-python` but this package is blocking and doesn't work with asyncio resulting in a blocked event loop. This PR switchs to `meilisearch-python-async` allowing for non-blocking calls.

I was unable to test because some of the needed files aren't included in the repo, `db.json` for example. If you test and have any issues I'm happy to make updates.